### PR TITLE
fix(lion): Fix bus store not finding buses

### DIFF
--- a/lion/bus/busStore.go
+++ b/lion/bus/busStore.go
@@ -5,6 +5,7 @@ import (
 	"sync"
 
 	. "github.com/eisandbar/BusPool/lion/typing"
+	"github.com/golang/geo/s1"
 	"github.com/golang/geo/s2"
 )
 
@@ -38,12 +39,23 @@ func (bs *MemoryBusStore) FindBus(client s2.LatLng) (Bus, error) {
 	if len(bs.bus) == 0 {
 		return Bus{}, errors.New("No buses available")
 	}
-	res, dist := bs.bus[0], client.Distance(bs.bus[0].Location).Abs()
+
+	found := false
+
+	res, dist := Bus{}, s1.Angle(2)
 	for _, bus := range bs.bus {
-		if client.Distance(bus.Location).Abs() < dist {
+		if client.Distance(bus.Location).Abs() <= dist && bus.Occupancy < bus.Capacity {
+			found = true
 			res = bus
 			dist = client.Distance(bus.Location).Abs()
 		}
 	}
+
+	if !found {
+		return Bus{}, errors.New("No buses available")
+	}
+
+	res.Occupancy++
+	bs.bus[res.Id] = res
 	return res, nil
 }

--- a/lion/endpoints/requests.go
+++ b/lion/endpoints/requests.go
@@ -2,6 +2,7 @@ package endpoints
 
 import (
 	"encoding/json"
+	"log"
 	"net/http"
 
 	"github.com/eisandbar/BusPool/lion/bus"
@@ -17,6 +18,7 @@ type RequestServer struct {
 
 // Handler for client requests
 func (rs RequestServer) RequestPost(w http.ResponseWriter, r *http.Request) {
+	log.Println("Processing request")
 	var req Request
 
 	decoder := json.NewDecoder(r.Body)


### PR DESCRIPTION
If no buses have available capacity then FindBus returns an error

FindBus updates occupancy in cases where a new request comes before
data from the bus propogates

Fixed bug where first bus could be closest but also full, so no buses
were assigned