### PR TITLE
fix(bus): Fix bad bus initialization

### DIFF
--- a/bus/bus.go
+++ b/bus/bus.go
@@ -15,13 +15,14 @@ import (
 	"github.com/golang/geo/s2"
 )
 
-const fleetSize = 20     // number of buses to initialize
+const fleetSize = 200    // number of buses to initialize
 const errAngle = 0.00015 // error allowance in coordinates
 
-func newBus(id int) *bus {
+func newBus(id int, coords [][]float64) *bus {
 	rand.Seed(time.Now().UnixMilli())
-	lat := 52.35 + rand.Float64()*0.3
-	lng := 13.1 + rand.Float64()*0.6
+	n := rand.Intn(len(coords))
+	lat := coords[n][0]
+	lng := coords[n][1]
 	location := s2.LatLngFromDegrees(lat, lng)
 	return &bus{
 		Bus: Bus{
@@ -107,6 +108,7 @@ func (b *bus) Move() {
 func (b *bus) requestHandler(client mqtt.Client, msg mqtt.Message) {
 	b.Lock()
 	defer b.Unlock()
+	log.Println("Received instructions for bus %d", b.Bus.Id)
 	var req Request
 	err := json.Unmarshal(msg.Payload(), &req)
 	if err != nil {

--- a/bus/internal/load.go
+++ b/bus/internal/load.go
@@ -1,0 +1,44 @@
+package internal
+
+import (
+	"encoding/json"
+	"io"
+	"log"
+	"os"
+)
+
+const (
+	file = "../data/export.geojson"
+)
+
+func LoadData() [][]float64 {
+	dataFile, err := os.Open(file)
+	defer dataFile.Close()
+	if err != nil {
+		log.Fatalf("Failed to open data file, %s", err)
+	}
+
+	byteData, err := io.ReadAll(dataFile)
+	if err != nil {
+		log.Fatalf("Failed to read data file, %s", err)
+	}
+
+	var geoData geoJson
+	json.Unmarshal(byteData, &geoData)
+
+	coordinates := make([][]float64, len(geoData.Features))
+	for i, feature := range geoData.Features {
+		// The json has it in [lon, lat]
+		coordinates[i] = []float64{feature.Geometry.Coordinates[1], feature.Geometry.Coordinates[0]}
+	}
+
+	return coordinates
+}
+
+type geoJson struct {
+	Features []struct {
+		Geometry struct {
+			Coordinates []float64 `json:"coordinates"`
+		} `json:"geometry"`
+	} `json:"features"`
+}

--- a/bus/main.go
+++ b/bus/main.go
@@ -8,10 +8,11 @@ import (
 )
 
 func main() {
+	coords := internal.LoadData()
 
 	fmt.Println("Starting")
 	for i := 0; i < fleetSize; i++ {
-		go internal.InitOne(internal.NewClient(), newBus(i), time.Tick(time.Second))
+		go internal.InitOne(internal.NewClient(), newBus(i, coords), time.Tick(time.Second))
 	}
 
 	fmt.Println("Fleet initialized")

--- a/bus/path/pathFinder.go
+++ b/bus/path/pathFinder.go
@@ -65,7 +65,6 @@ func generateRequest(points []s2.LatLng) io.Reader {
 func getPoints(coords [][]float64) []s2.LatLng {
 	points := make([]s2.LatLng, len(coords))
 	for i, coord := range coords {
-		fmt.Println(coord)
 		points[i] = s2.LatLngFromDegrees(coord[1], coord[0]) // coords come as [lon, lat]
 	}
 	return points


### PR DESCRIPTION
Buses would spawn in random locations and graphHopper would not be able to
find a path for them.

Now program loads a list of bus stop coordinates and when creating a new bus
spawns at a random bus stop.

Increased fleet size